### PR TITLE
Update SDK to 1.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5667,7 +5667,7 @@
       }
     },
     "node_modules/th1": {
-      "version": "1.12.0",
+      "version": "1.14.2",
       "resolved": "git+ssh://git@github.com/uol-esis/TH1-JS-Client.git#05121359b914df41caa1ae4a297f3eefce43ddfc",
       "license": "Unlicense",
       "dependencies": {


### PR DESCRIPTION
Update SDK to 1.14.2
Changes:
 - Added FillEmptyColumnStructure
 - TableStructure deletion now passes the parameter via the path (this does not change the usage)
 - feedback id is now a UUID provided as a string (was a number before)