### PR TITLE
79 abfangen von gleichen dateien

### DIFF
--- a/src/Popups/ConfirmNameDialog.jsx
+++ b/src/Popups/ConfirmNameDialog.jsx
@@ -1,18 +1,23 @@
 import { useState, useEffect } from "react";
-export default function ConfirmNameDialog({dialogRef, name, onCLickFunction}){
-
+export default function ConfirmNameDialog({dialogRef, name, onClickFunction, errorText}){
+    const [error, setError] = useState(errorText)
     const [text, setText] = useState(name);
 
     useEffect(() => {
         setText(name);
     }, [name]);
 
+    useEffect(() => {
+        setError(errorText);
+    }, [errorText]);
+
     return(
-        <dialog  className="justify-self-center mt-[20vh] h-[30vh] w-[50vw] shadow-md bg-white " ref={dialogRef}>
+        <dialog  className="justify-self-center mt-[20vh] w-[50vw] shadow-md bg-white " ref={dialogRef}>
             <div className="flex flex-col justify-between h-full p-5 bg-white">
                 <p className="text font-semibold ">Tabellentransformationsnamen bestätigen oder bearbeiten</p>
                 {/* Text input */} 
                 <div className="flex flex-col">
+                    <p className="text-sm font-semibold text-red-800 bg-red-200">{error}</p>
                     <label htmlFor="username" className=" text-left block text-sm/6 font-medium text-gray-900">
                         Generierter Tabellentarnsformationsname:
                     </label>
@@ -28,7 +33,7 @@ export default function ConfirmNameDialog({dialogRef, name, onCLickFunction}){
                         </div>
                 </div>
                 {/* Buttons */}
-                <div className="flex justify-between">
+                <div className="flex mt-2 justify-between">
                     <button
                         className=" p-5 rounded-md bg-gray-600 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                         onClick={() => {dialogRef.current?.close()}}
@@ -37,8 +42,7 @@ export default function ConfirmNameDialog({dialogRef, name, onCLickFunction}){
                     </button>
                     <button
                         onClick={() => {
-                            onCLickFunction(text);
-                            dialogRef.current?.close();
+                            onClickFunction(text);
                         }}
                         className=" p-5 rounded-md bg-gray-600 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                     >

--- a/src/Popups/DecisionDialog.jsx
+++ b/src/Popups/DecisionDialog.jsx
@@ -1,0 +1,28 @@
+import { InformationCircleIcon } from '@heroicons/react/20/solid'
+
+export default function DecisionDialog({dialogRef, text,label1, function1, label2, function2}){
+
+    return(
+        <dialog  className=" justify-self-center mt-[20vh] w-[30vw] shadow-md bg-white " ref={dialogRef}>
+            <div className="flex flex-col place-items-center p-5 gap-5 bg-white">
+                <InformationCircleIcon aria-hidden="true" className="size-20 text-gray-400" />
+                <p>{text}</p>
+                <button
+                    className=" p-5 w-[15vw] rounded-md bg-gray-600 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    onClick={function1}
+                >
+                    {label1}
+                </button>
+
+                <button
+                    className=" p-5 w-[15vw] rounded-md bg-gray-600 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    onClick={function2}
+                >
+                    {label2}
+                </button>
+                
+            </div>
+            
+        </dialog>
+    );
+}

--- a/src/Popups/ErrorDialog.jsx
+++ b/src/Popups/ErrorDialog.jsx
@@ -1,4 +1,27 @@
-export default function ErrorDialog({dialogRef, text, onConfirm, errorMsg}){
+import { useState, useEffect} from "react";
+
+export default function ErrorDialog({dialogRef, text, onConfirm, errorId}){
+
+    const [errorMsg, setErrorMsg] = useState("");
+    const locale = "errorsDE";
+
+    {/* load error message based on id */}
+    useEffect(() => {
+        fetch(`src/language/${locale}.json`)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Netzwerkfehler: ' + response.status);
+                }
+                return response.json();
+            })
+            .then(data => {
+                setErrorMsg(data[errorId]);
+            })
+            .catch(error => {
+                console.error('Fehler beim Laden oder Verarbeiten:', error);
+            });
+    }, [errorId])
+
     return(
         <dialog  className=" justify-self-center p-5 mt-[20vh] w-[30vw] shadow-md bg-white " ref={dialogRef}>
             <div className="flex flex-col place-items-center p-5 gap-5 bg-white">

--- a/src/Preview.jsx
+++ b/src/Preview.jsx
@@ -14,7 +14,9 @@ import { ExclamationTriangleIcon } from '@heroicons/react/20/solid'
 import ErrorDialog from "./Popups/ErrorDialog";
 import { StackedList } from "./StackedList";
 import { useAuthGuard } from "./hooks/AuthGuard";
+import { getApiInstance } from "./hooks/ApiInstance";
 import keycloak from "./keycloak";
+import DecisionDialog from "./Popups/DecisionDialog";
 
 export default function Preview() {
 
@@ -29,7 +31,8 @@ export default function Preview() {
   const [allCheck, setAllCheck] = useState(false);
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [showError, setShowError] = useState(false);
-  const [errorText, setErrorText] = useState("");
+  const [errorId, setErrorId] = useState("");
+  const [globalSchemaId, setGlobalSchemaId] = useState("");
   const [windowSize, setWindowSize] = useState({
     width: window.innerWidth,
     height: window.innerHeight
@@ -40,6 +43,7 @@ export default function Preview() {
   const checkboxDialogRef = useRef();
   const uploadFinishedDialogRef = useRef();
   const errorDialogRef = useRef();
+  const decisionDialogRef = useRef();
 
 
   useEffect(() => {
@@ -114,7 +118,7 @@ export default function Preview() {
         }
         console.log("Using selected schema: ", actualSchemaRef.current);
       }
-
+      
       console.log("Actual schema set: ", actualSchemaRef.current);
     } catch (error) {
       console.error("Error during setActualSchema:", error);
@@ -177,15 +181,50 @@ export default function Preview() {
         schemaId = selectedSchema.id;
       }
 
-      console.log("schemaId " + schemaId);
       api.convertTable(schemaId, selectedFile, undefined, (error, data, response) => {
         if (error) {
           console.error(error);
-          reject(error);
+          const errorObj = JSON.parse(error.message);
+          if(errorObj.statusCode == "409"){
+            decisionDialogRef.current?.showModal();
+            resolve("decision");
+          }else{
+            setErrorId(errorObj.status);
+            reject(error);
+          }
         } else {
           resolve(data);
         }
       });
+    });
+  }
+
+  const replaceTableInServer = (schemaId) => {
+    //if schema is not generated, get id from selected schema
+    if(!schemaId) schemaId = actualSchemaRef.current.id;
+
+    const client = new ApiClient(import.meta.env.VITE_API_ENDPOINT);
+    const oAuth2Auth = client.authentications["oAuth2Auth"];
+    oAuth2Auth.accessToken = keycloak.token; // Use Keycloak token for authentication
+    const api = new DefaultApi(client);
+
+    let opts = {
+      'mode': "'REPLACE'"
+    };
+
+    api.convertTable(schemaId, selectedFile, opts, (error, data, response) => {
+      if (error) {
+        console.error(error);
+        const errorObj = JSON.parse(error.message);
+        setErrorId(errorObj.status);
+        decisionDialogRef.current?.close();
+        errorDialogRef.current?.showModal();
+
+      } else {
+        decisionDialogRef.current?.close();
+        uploadFinishedDialogRef.current?.showModal();
+        console.log('Table successfully replaced.');
+      }
     });
   }
 
@@ -202,6 +241,11 @@ export default function Preview() {
     return new Promise((resolve, reject) => {
       api.createTableStructure(generatedSchema, (error, data, response) => {
         if (error) {
+          const errorObj = JSON.parse(error.message);
+          if(errorObj.status == "409"){
+            setErrorId(errorObj.status + "CreateTableStructure");
+          }else setErrorId(errorObj.status);
+          
           reject(error);
         } else {
           console.log('API called successfully. data: ', data);
@@ -224,6 +268,10 @@ export default function Preview() {
     return new Promise((resolve, reject) => {
       api.createTableStructure(editedSchema, (error, data, response) => {
         if (error) {
+          const errorObj = JSON.parse(error.message);
+          if(errorObj.status == "409"){
+            setErrorId(errorObj.status + "CreateTableStructure");
+          }else setErrorId(errorObj.status);
           reject(error);
         } else {
           console.log('API called successfully. data: ', data);
@@ -284,6 +332,15 @@ export default function Preview() {
               Bearbeitung erfolgreich angewandt! Bitte überprüfen Sie die Vorschau und laden Sie die korrekte Datei hoch!        </div>
           )}
         {/* Popups */}
+          <DecisionDialog
+            dialogRef={decisionDialogRef}
+            text={"Die Datei befindet sich bereits in der Datenbank. Es gibt die Möglichkeit die Datei zu ersetzen oder das Hochladen abzubrechen."}
+            label1={"Datei ersetzen"}
+            function1={() => {replaceTableInServer(globalSchemaId)}}
+            label2={"Hochladen abbrechen"}
+            function2={() => navigate("/upload")}
+          />
+
         <HelpDialog dialogRef={helpDialogRef} />
 
         <UploadDialog
@@ -298,22 +355,26 @@ export default function Preview() {
           allCheck={allCheck}
           setAllCheck={setAllCheck}
           onConfirm={async () => {
+            let schemaId = null;
             checkboxDialogRef.current?.close();
             try {
-              let schemaId = null;
               if (generatedSchema) {
                 schemaId = await sendGeneratedSchemaToServer();
               } else if (editedSchema) {
                 schemaId = await sendEditedSchemaToServer();
               }
-              await sendTableToServer(schemaId);
-              uploadFinishedDialogRef.current?.showModal();
+              setGlobalSchemaId(schemaId)
+              const result = await sendTableToServer(schemaId);
+              if(result == "decision"){
+                decisionDialogRef.current?.showModal();
+              }else{
+                uploadFinishedDialogRef.current?.showModal();
+              }
+              
             } catch (error) {
-              console.log("catched");
-              setErrorText(error.message);
+              console.error(error);
               errorDialogRef.current?.showModal();
-            }
-
+              }
           }}
         />
 
@@ -321,7 +382,7 @@ export default function Preview() {
 
         <ErrorDialog
           text={"Upload fehlgeschlagen "}
-          errorMsg={""}
+          errorId={errorId}
           onConfirm={() => { errorDialogRef.current?.close(); navigate("/"); }}
           dialogRef={errorDialogRef}
         />

--- a/src/Upload.jsx
+++ b/src/Upload.jsx
@@ -32,6 +32,7 @@ function Upload() {
   const [jsonData, setJsonData] = useState(null);
   const [isValidFile, setIsValidFile] = useState(false);
   const fileInputRef = useRef(null); // Reference for the hidden input element
+  const [confirmNameError, setConfirmNameError] = useState();
 
   const [tipDate, setTipData] = useState(false);
   const [tipSchema, setTipSchema] = useState(false);
@@ -139,7 +140,7 @@ function Upload() {
       console.error("Th1 module is not loaded yet.");
       return;
     }
-    console.log("try to generate");
+    
     const client = new Th1.ApiClient(import.meta.env.VITE_API_ENDPOINT);
     const oAuth2Auth = client.authentications["oAuth2Auth"];
     oAuth2Auth.accessToken = keycloak.token; // Use Keycloak token for authentication
@@ -163,8 +164,23 @@ function Upload() {
     api.generateTableStructure(selectedFile, settings, callback);
   }
 
+  const isNameTaken = function (newName) {
+    for (const schema of schemaList) {
+      if (schema.name === newName) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   {/* Confirm name and navigate to preview page*/ }
   const confirmGeneratedName = function (newName) {
+    
+    if(isNameTaken(newName)){
+      setConfirmNameError("Der Name wird bereits verwendet");
+      return;
+    }
+
     jsonData.name = newName;
     const cleaned = JSON.parse(JSON.stringify(jsonData));
     navigate("/preview", { state: { selectedFile, generatedSchema: cleaned } }) // or data // Pass data to preview page
@@ -179,11 +195,13 @@ function Upload() {
     fileInputRef.current.click();
   };
 
-  //noch ausfüllen
+
   const handleAddSchema = () => {
     setSchemaName(selectedFile.name);
     confirmNameToEditRef.current?.showModal();
   };
+
+  //TODO name is not set
   const handleConfirmNewSchema = () => {
     navigate("/edit", {
       state: {
@@ -199,8 +217,8 @@ function Upload() {
     !isLoggedIn ? <div>Not logged in</div>:
     <div className="flex flex-col h-[80vh] w-full gap-1 p-3">
       {/* Popup */}
-      <ConfirmNameDialog dialogRef={confirmNameToPreviewRef} name={schemaName} onCLickFunction={confirmGeneratedName} />
-      <ConfirmNameDialog dialogRef={confirmNameToEditRef} name={schemaName} onCLickFunction={() => handleConfirmNewSchema()} />
+      <ConfirmNameDialog dialogRef={confirmNameToPreviewRef} name={schemaName} errorText={confirmNameError} onClickFunction={confirmGeneratedName} />
+      <ConfirmNameDialog dialogRef={confirmNameToEditRef} name={schemaName} errorText={confirmNameError} onClickFunction={() => handleConfirmNewSchema()} />
 
       {/* Go back and Tutorial */}
       <div className="flex justify-between">

--- a/src/components/ConverterCard.jsx
+++ b/src/components/ConverterCard.jsx
@@ -67,6 +67,18 @@ export default function ConverterCard({id, label, parameters, converterType, for
 
         parameters.forEach(param => {
             const value = formData[param.apiName];
+
+            /*  
+            if(param.type == "string" && param.required &&  (!value || value.toString().trim() === '') ){
+                formData[param.apiName] = "";
+                return;
+            }
+           */
+            if(converterType == "REPLACE_ENTRIES" && param.apiName == "search" && (!value || value.toString().trim() === '')) {
+                formData[param.apiName] = "";
+                return;
+            } 
+
             if (param.required && (!value || value.toString().trim() === '')) {
             newErrors[param.apiName] = 'Dieses Feld ist erforderlich.';
             } 

--- a/src/language/errorsDE.json
+++ b/src/language/errorsDE.json
@@ -1,0 +1,7 @@
+{
+    "200": "Die Anfrage war erfolgreich.",
+    "400": "Es wurde eine fehlerhafte Anfrage an den Server gestellt.",
+    "401": "Der Zugriff ist nicht autorisiert.",
+    "404": "Die angefragten Informationen konnten nicht gefunden werden.",
+    "409": "Die Datei existiert bereits in der Datenbank."
+}

--- a/src/language/errorsDE.json
+++ b/src/language/errorsDE.json
@@ -3,5 +3,7 @@
     "400": "Es wurde eine fehlerhafte Anfrage an den Server gestellt.",
     "401": "Der Zugriff ist nicht autorisiert.",
     "404": "Die angefragten Informationen konnten nicht gefunden werden.",
-    "409": "Die Datei existiert bereits in der Datenbank."
+    "409ConvertTable": "Die Datei existiert bereits in der Datenbank.",
+    "409CreateTableStructure": "Der Tabellentransformationsname wird bereits verwendet.",
+    "500": "Interner Server Error."
 }


### PR DESCRIPTION
- Bei dem Converter "Einträge ersetzen" kann der Suchbegriff leer gelassen werden, um leere Zellen zu befüllen.
- Es wird bei der Namensvergabe bei der Generierung eines neuen Schemas überprüft, ob der Name bereits verwendet wird.
- Wenn sich die hochgeladene Datei bereits in der DB befindet, dann kann diese nun ersetzt werden.
- Das Error Popup zeigt einen Fehlertext basierend auf dem Fehlercode an (noch ausbaufähig).
