### PR TITLE
Update SDK to 1.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6411,10 +6411,8 @@
       }
     },
     "node_modules/th1": {
-      "version": "1.23.0",
-      "resolved": "git+ssh://git@github.com/uol-esis/TH1-JS-Client.git#c56fd4d50ebc822d80b7055607bf7e34e5422991",
-      "version": "1.23.0",
-      "resolved": "git+ssh://git@github.com/uol-esis/TH1-JS-Client.git#c56fd4d50ebc822d80b7055607bf7e34e5422991",
+      "version": "1.25.0",
+      "resolved": "git+ssh://git@github.com/uol-esis/TH1-JS-Client.git#ddb53810b0683c0aa2c999c53f89d8a773de9d62",
       "license": "Unlicense",
       "dependencies": {
         "@babel/cli": "^7.0.0",


### PR DESCRIPTION
BREAKING CHANGES:

 - Renamed SplitRowStructure to SplitCellStructure. The Structure now has a mode field. If it is set to "row" the converter will split the cells into new rows, replacing the old row. If it is set to "column", the converter will split the cells into new columns. If the cells do not have the same amount of entries if split, the rest will be empty strings. Above and below the rows which are affected by the split, the entries will be kept in the left most cell. The rest will be empty.

Changes:

 - Added RemoveKeywordsStructure
 - Added RemoveKeywordsSettings