### PR TITLE
Use static data import for error messages

### DIFF
--- a/src/Popups/ErrorDialog.jsx
+++ b/src/Popups/ErrorDialog.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect} from "react";
+import dataString from "../language/errorsDE.json?raw";
 
 export default function ErrorDialog({dialogRef, text, onConfirm, errorId}){
 
@@ -7,19 +8,8 @@ export default function ErrorDialog({dialogRef, text, onConfirm, errorId}){
 
     {/* load error message based on id */}
     useEffect(() => {
-        fetch(`src/language/${locale}.json`)
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Network error: ' + response.status);
-                }
-                return response.json();
-            })
-            .then(data => {
-                setErrorMsg(data[errorId]);
-            })
-            .catch(error => {
-                console.error('Error loading or processing:', error);
-            });
+        const data = JSON.parse(dataString);
+        setErrorMsg(data[errorId]);
     }, [errorId])
 
     return(


### PR DESCRIPTION
Die alte Variante hat versucht die Fehlermeldungen aus dem `src` Ordner per fetch (also per Anfrage übers Netzwerk) zu erhalten. Da der `src` Ordner im "kompilierten" Zusatand nicht mehr vorhanden ist, kann die Datei dort nicht gefunden werden. Es gibt verschiedene Wege, statische Ressourcen zu laden. Eine davon habe ich hier implementiert.


Sources:
- https://vite.dev/guide/assets.html#importing-asset-as-string
- https://stackoverflow.com/a/76322251
