### PR TITLE
Update to docker dns server

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -3,9 +3,8 @@ server {
     server_name _;
     client_max_body_size 200M;
 
-    # Setting the dns resolver (Google DNS).
-    # I'm not sure, why this is required, but without it, the API calls fail because the 'injected' API HOST cant be resolved ¯\_(ツ)_/¯
-    resolver 8.8.8.8;
+    # DNS resolver needed for Docker
+    resolver 127.0.0.11 valid=10s;
 
     # default routing of requests to the normal frontend files
     location / {


### PR DESCRIPTION
The nginx configuration was not able to resolve dns entries defined by other services in the same docker network. By setting the correct dns resolver, this now has been fixed-